### PR TITLE
Stopped setting default values for element and target properties on contextual event.

### DIFF
--- a/src/__tests__/initRules.test.js
+++ b/src/__tests__/initRules.test.js
@@ -204,9 +204,7 @@ describe('initRules', function() {
       });
 
       expect(condition1ExportsCall.args[1]).toEqual({
-        type: 'test-extension.test-event',
-        element: window,
-        target: window
+        type: 'test-extension.test-event'
       });
 
       var condition2Exports = moduleProvider.getModuleExports(TEST_CONDITION2_PATH);
@@ -220,9 +218,7 @@ describe('initRules', function() {
       });
 
       expect(condition2ExportsCall.args[1]).toEqual({
-        type: 'test-extension.test-event',
-        element: window,
-        target: window
+        type: 'test-extension.test-event'
       });
 
       var action1Exports = moduleProvider.getModuleExports(TEST_ACTION1_PATH);
@@ -236,9 +232,7 @@ describe('initRules', function() {
       });
 
       expect(action1ExportsCall.args[1]).toEqual({
-        type: 'test-extension.test-event',
-        element: window,
-        target: window
+        type: 'test-extension.test-event'
       });
 
       var action2Exports = moduleProvider.getModuleExports(TEST_ACTION2_PATH);
@@ -252,9 +246,7 @@ describe('initRules', function() {
       });
 
       expect(action2ExportsCall.args[1]).toEqual({
-        type: 'test-extension.test-event',
-        element: window,
-        target: window
+        type: 'test-extension.test-event'
       });
     });
 

--- a/src/__tests__/normalizeSyntheticEvent.test.js
+++ b/src/__tests__/normalizeSyntheticEvent.test.js
@@ -20,27 +20,7 @@ describe('normalizeSyntheticEvent', function() {
   it('creates a synthetic event with defaults if synthetic event is undefined', function() {
     var syntheticEvent = normalizeSyntheticEvent(MOCK_TYPE);
     expect(syntheticEvent).toEqual({
-      type: MOCK_TYPE,
-      element: window,
-      target: window
-    });
-  });
-
-  it('element and targetElement are derived from nativeEvent if nativeEvent exists', function() {
-    var nativeEvent = {
-      currentTarget: {},
-      target: {}
-    };
-
-    var syntheticEvent = normalizeSyntheticEvent(MOCK_TYPE, {
-      nativeEvent: nativeEvent
-    });
-
-    expect(syntheticEvent).toEqual({
-      type: MOCK_TYPE,
-      element: nativeEvent.currentTarget,
-      target: nativeEvent.target,
-      nativeEvent: nativeEvent
+      type: MOCK_TYPE
     });
   });
 
@@ -50,18 +30,5 @@ describe('normalizeSyntheticEvent', function() {
     });
 
     expect(syntheticEvent.type).toBe(MOCK_TYPE);
-  });
-
-  it('does not overwrite element or target if set', function() {
-    var element = {};
-    var target = {};
-
-    var syntheticEvent = normalizeSyntheticEvent(MOCK_TYPE, {
-      element: element,
-      target: target
-    });
-
-    expect(syntheticEvent.element).toBe(element);
-    expect(syntheticEvent.target).toBe(target);
   });
 });

--- a/src/normalizeSyntheticEvent.js
+++ b/src/normalizeSyntheticEvent.js
@@ -11,8 +11,7 @@
  ****************************************************************************************/
 
 /**
- * Normalizes a synthetic event so that it exists and has at least type, element, and target
- * properties.
+ * Normalizes a synthetic event so that it exists and has at least type.
  * @param {string} syntheticEventType
  * @param {Object} [syntheticEvent]
  * @returns {Object}
@@ -20,15 +19,5 @@
 module.exports = function(syntheticEventType, syntheticEvent) {
   syntheticEvent = syntheticEvent || {};
   syntheticEvent.type = syntheticEventType;
-
-  var nativeEvent = syntheticEvent.nativeEvent;
-
-  syntheticEvent.element = syntheticEvent.element ||
-    (nativeEvent && nativeEvent.currentTarget) ||
-    window;
-  syntheticEvent.target = syntheticEvent.target ||
-    (nativeEvent && nativeEvent.target) ||
-    window;
-
   return syntheticEvent;
 };


### PR DESCRIPTION
Copied from JIRA:

When an extension has an event type which triggers a rule, it can pass a contextual event to the {{trigger}} function. If they don't set {{element}} or {{target}} on the contextual event, Turbine sets them to default values (typically {{window}} unless they've provided {{nativeEvent}} on the contextual event, in which case they are derived from properties on {{nativeEvent}}). We want to remove the setting of default values for {{element}} and {{target}} on contextual event data. This means that if the extension developer does not explicitly set them on the contextual event object, they will remain {{undefined}}.

This means that if a contextual event does not have {{element}} or {{target}} explicitly defined, then the following will result in undefined values:

{{%this.whatever%}}
 {{%target.whatever%}}
 {{%event.element.whatever%}}
 {{%event.target.whatever%}}

Similarly, in a custom code condition or action, {{target}}, {{event.target}}, and {{event.element}} will be {{undefined}}. The {{this}} variable will be {{window}}, because the {{browser}} won't let {{this}} be {{undefined}} and automatically defaults it to {{window}}.