### PR TITLE
DTM-10915 Added support for rule ordering.

### DIFF
--- a/src/__tests__/buildRuleExecutionOrder.test.js
+++ b/src/__tests__/buildRuleExecutionOrder.test.js
@@ -1,0 +1,130 @@
+/***************************************************************************************
+ * (c) 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+var buildRuleExecutionOrder = require('../buildRuleExecutionOrder');
+
+describe('buildRuleExecutionOrder', function() {
+  it('orders rules whose order is swapped in different events', function() {
+    var ruleA = {
+      events: [
+        {
+          "modulePath": "event1.js",
+          ruleOrder: 100
+        },
+        {
+          "modulePath": "event2.js",
+          ruleOrder: 200
+        }
+      ]
+    };
+
+    var ruleB = {
+      events: [
+        {
+          "modulePath": "event1.js",
+          ruleOrder: 200
+        },
+        {
+          "modulePath": "event2.js",
+          ruleOrder: 100
+        }
+      ]
+    };
+
+    var executionOrder = buildRuleExecutionOrder([
+      ruleA,
+      ruleB
+    ]);
+
+    expect(executionOrder).toEqual([
+      {
+        rule: ruleA,
+        event: ruleA.events[0]
+      },
+      {
+        rule: ruleB,
+        event: ruleB.events[1]
+      },
+      {
+        rule: ruleA,
+        event: ruleA.events[1]
+      },
+      {
+        rule: ruleB,
+        event: ruleB.events[0]
+      }
+    ]);
+  });
+
+  it('maintains the natural order to no ruleOrder provided', function() {
+    // Note that we don't provide a default ruleOrder value. This is because ruleOrder will
+    // be required in the container schema. However, when users are testing things out in the
+    // sandbox, it's nice to be able to leave off ruleOrder and have the rules still execute
+    // in a reasonable order.
+    var ruleA = {
+      events: [
+        {
+          "modulePath": "event1.js"
+        }
+      ]
+    };
+
+    var ruleB = {
+      events: [
+        {
+          "modulePath": "event1.js"
+        }
+      ]
+    };
+
+    var ruleC = {
+      events: [
+        {
+          "modulePath": "event1.js"
+        }
+      ]
+    };
+
+    var exectionOrder = buildRuleExecutionOrder([
+      ruleA,
+      ruleB,
+      ruleC
+    ]);
+
+    expect(exectionOrder).toEqual([
+      {
+        rule: ruleA,
+        event: ruleA.events[0]
+      },
+      {
+        rule: ruleB,
+        event: ruleB.events[0]
+      },
+      {
+        rule: ruleC,
+        event: ruleC.events[0]
+      }
+    ]);
+  });
+
+  it('handles rules with no events', function() {
+    var ruleA = {
+      events: []
+    };
+
+    var executionOrder = buildRuleExecutionOrder([
+      ruleA
+    ]);
+
+    expect(executionOrder).toEqual([]);
+  });
+});

--- a/src/buildRuleExecutionOrder.js
+++ b/src/buildRuleExecutionOrder.js
@@ -1,0 +1,42 @@
+/***************************************************************************************
+ * (c) 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+/**
+ * Rules can be ordered by users at the event type level. For example, assume both Rule A and Rule B
+ * use the Library Loaded and Window Loaded event types. Rule A can be ordered to come before Rule B
+ * on Library Loaded but after Rule B on Window Loaded.
+ *
+ * Order values are integers and act more as a priority. In other words, multiple rules can have the
+ * same order value. If they have the same order value, their order of execution should be
+ * considered nondetermistic.
+ *
+ * @param {Array} rules
+ * @returns {Array} An ordered array of rule-event pair objects.
+ */
+module.exports = function(rules) {
+  var ruleEventPairs = [];
+
+  rules.forEach(function(rule) {
+    if (rule.events) {
+      rule.events.forEach(function(event) {
+        ruleEventPairs.push({
+          rule: rule,
+          event: event
+        });
+      });
+    }
+  });
+
+  return ruleEventPairs.sort(function(ruleEventPairA, ruleEventPairB) {
+    return ruleEventPairA.event.ruleOrder - ruleEventPairB.event.ruleOrder;
+  });
+};


### PR DESCRIPTION
I decided not to provide a default `ruleOrder` value since we'll require it in the container schema. If no events from any of the rules have `ruleOrder` (like could be the case when using the extension sandbox), then the rules will be run in the order they were in inside the container. I think that's sufficient.