### PR TITLE
Remove warning when publishing the package to NPM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "rollup -c --intro \"if (!window.atob) { console.warn('Adobe Launch is unsupported in IE 9 and below.'); return; }\" && uglifyjs dist/engine.js -c -m -o dist/engine.min.js",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "test": "karma start",
     "test:watch": "npm test -- --no-single-run --no-coverage",
     "lint": "eslint 'src/**/*.js'"


### PR DESCRIPTION
When I pushed the latest version of Turbine I received the following warnings:

```
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```

I'm guessing the intention of using prepublish was to force a Turbine build before uploading it to NPM. If that's the case `prepublishOnly` should still take care of this case. Otherwise we should use `prepare.

More info here:
https://docs.npmjs.com/misc/scripts#prepublish-and-prepare.