### PR TITLE
Adds querystring readers to _satellite

### DIFF
--- a/src/__tests__/hydrateSatelliteObject.test.js
+++ b/src/__tests__/hydrateSatelliteObject.test.js
@@ -100,6 +100,48 @@ describe('hydrateSatelliteObject', function() {
     expect(_satellite.cookie.set).toEqual(jasmine.any(Function));
     expect(_satellite.cookie.remove).toEqual(jasmine.any(Function));
   });
+  
+  it('can read query parameters', function() {
+	var hydrateSatelliteObject = injectHydrateSatelliteObject();
+    hydrateSatelliteObject(_satellite, container);  
+	  
+	var oldSearch = window.location.search;
+	var testString = 'foo=bar&Buzz=Fizz&spaceIncluded=space%20included';
+	
+	expect(_satellite.query.read("foo", undefined, testString)).toEqual("bar");
+	expect(_satellite.query.read("buzz", undefined, testString)).toBeUndefined();
+	expect(_satellite.query.read("Buzz", undefined, testString)).toEqual("Fizz");
+	expect(_satellite.query.read("spaceIncluded", undefined, testString)).toEqual("space included");
+	
+	expect(_satellite.query.readCaseInsensitive("foo", testString)).toEqual("bar");
+	expect(_satellite.query.readCaseInsensitive("buzz", testString)).toEqual("Fizz");
+	expect(_satellite.query.readCaseInsensitive("Buzz", testString)).toEqual("Fizz");
+	expect(_satellite.query.readCaseInsensitive("spaceincluded", testString)).toEqual("space included");
+	
+  });
+  
+  it('exposes querystring read methods', function() {
+    var logger = {
+      warn: jasmine.createSpy(),
+      createPrefixedLogger: function() {}
+    };
+    var hydrateSatelliteObject = injectHydrateSatelliteObject({
+      './logger': logger
+    });
+    hydrateSatelliteObject(_satellite, container);
+
+    expect(_satellite.getQueryParam).toEqual(jasmine.any(Function));
+    expect(_satellite.getQueryParamCaseInsensitive).toEqual(jasmine.any(Function));
+	
+	//test that deprecation warnings are issued
+	_satellite.getQueryParam("queryParam");
+	expect(logger.warn).toHaveBeenCalledWith(
+      '_satellite.getQueryParam is deprecated. Please use _satellite.query.read("queryParam").');
+	  
+	 _satellite.getQueryParamCaseInsensitive("queryParam");
+	expect(logger.warn).toHaveBeenCalledWith(
+      '_satellite.getQueryParamCaseInsensitive is deprecated. Please use _satellite.query.readCaseInsensitive("queryParam").');
+  });
 
   it('exposes a logger', function() {
     var hydrateSatelliteObject = injectHydrateSatelliteObject();


### PR DESCRIPTION
At Cox Automotive, we gracefully fallback on querystring params when information is not provided in our data layer. Being able to programatically fallback to these params is important for us. We looked at alternative means to accomplish this without getQueryParam:

- Include a data element for every query param we would like to look up, then perform a `_satellite.getVar`. This would be annoying for us to maintain and isn't elegant, but we will temporarily be using this unless this pull request gets published.
- Include a function to read query parameters inside every data element that uses them. This violates DRY and wastes our user's bandwidth.

Creating multiple source data-elements in the UI without the need for custom code for fallback would be our dream state. Being able to set, on the Launch UI: "pageName is dataLayer.page.pageName OR alternateDataLayer.pageName OR queryParam("pageName") OR Core(Page.URL) would be phenomenal. I suspect many users might find it helpful based on my previous consulting experience. Allowing for fallback to be defined within the UI would help non-developers maintain their tagging.

This pull request returns the .getQueryParam and it's case insensitive brother to _satellite from DTM. The namespace was changed to be like cookie: keep the old function, but throw a deprecation. I used a modified version of the function Launch uses to decode queryString parameters `core/src/lib/dataElements/queryStringParameter.js` (which incidentally isn't in this repo and I found within our site's compiled code). I added decodeURIComponent to that function, and would suggest adding it to `core/src/lib/dataElements/queryStringParameter.js` as well to prevent "what is 'adobe%20marketing%20cloud'?" issues.