### PR TITLE
DTM-12430 Log message when track() is called.

### DIFF
--- a/src/__tests__/hydrateSatelliteObject.test.js
+++ b/src/__tests__/hydrateSatelliteObject.test.js
@@ -29,11 +29,20 @@ describe('hydrateSatelliteObject', function() {
   });
 
   it('should add a track function on _satellite', function() {
-    var hydrateSatelliteObject = injectHydrateSatelliteObject();
+    var logger = {
+      log: jasmine.createSpy(),
+      createPrefixedLogger: function() {}
+    };
+    var hydrateSatelliteObject = injectHydrateSatelliteObject({
+      './logger': logger
+    });
     hydrateSatelliteObject(_satellite, container);
     expect(_satellite.track).toEqual(jasmine.any(Function));
     // shouldn't throw an error.
-    _satellite.track();
+    _satellite.track('checkout');
+    expect(logger.log).toHaveBeenCalledWith(
+      '"checkout" does not match any direct call identifiers.'
+    );
   });
 
   it('should add a getVisitorId function on _satellite', function() {

--- a/src/hydrateSatelliteObject.js
+++ b/src/hydrateSatelliteObject.js
@@ -14,13 +14,15 @@ var cookie = require('@adobe/reactor-cookie');
 var logger = require('./logger');
 
 module.exports = function(_satellite, container, setDebugOutputEnabled, getVar, setCustomVar) {
-  var prefixedLogger = logger.createPrefixedLogger('Custom Script');
+  var customScriptPrefixedLogger = logger.createPrefixedLogger('Custom Script');
 
   // Will get replaced by the directCall event delegate from the Core extension. Exists here in
   // case there are no direct call rules (and therefore the directCall event delegate won't get
   // included) and our customers are still calling the method. In this case, we don't want an error
   // to be thrown. This method existed before Reactor.
-  _satellite.track = function() {};
+  _satellite.track = function(identifier) {
+    logger.log('"' + identifier + '" does not match any direct call identifiers.');
+  };
 
   // Will get replaced by the Marketing Cloud ID extension if installed. Exists here in case
   // the extension is not installed and our customers are still calling the method. In this case,
@@ -35,7 +37,7 @@ module.exports = function(_satellite, container, setDebugOutputEnabled, getVar, 
 
   _satellite.buildInfo = container.buildInfo;
 
-  _satellite.logger = prefixedLogger;
+  _satellite.logger = customScriptPrefixedLogger;
 
   /**
    * Log a message. We keep this due to legacy baggage.
@@ -48,16 +50,16 @@ module.exports = function(_satellite, container, setDebugOutputEnabled, getVar, 
 
     switch (level) {
       case 3:
-        prefixedLogger.info(message);
+        customScriptPrefixedLogger.info(message);
         break;
       case 4:
-        prefixedLogger.warn(message);
+        customScriptPrefixedLogger.warn(message);
         break;
       case 5:
-        prefixedLogger.error(message);
+        customScriptPrefixedLogger.error(message);
         break;
       default:
-        prefixedLogger.log(message);
+        customScriptPrefixedLogger.log(message);
     }
   };
 


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/DTM-12430

When a website calls `_satellite.track()` and no direct call rules were included in the library, nothing is logged to the console because it's just calling the empty stubbed `_satellite.track` method. The stub isn't ever overwritten by the Core extension because there aren't any direct call rules in the library. This change adds some logging to the stub so the user can know there's no matching direct call rule.