### PR TITLE
Add support for referencing event from data element library module.

### DIFF
--- a/src/__tests__/createGetVar.test.js
+++ b/src/__tests__/createGetVar.test.js
@@ -27,12 +27,15 @@ describe('function returned by createGetVar', function() {
     getDataElementDefinition = function() {
       return {};
     };
-    getDataElementValue = function() {
+    getDataElementValue = jasmine.createSpy().and.callFake(function() {
       return 'baz';
-    };
+    });
     var getVar = createGetVar(customVars, getDataElementDefinition, getDataElementValue);
+    var event = {};
 
-    expect(getVar('unicorn.foo.bar')).toBe('baz');
+    var value = getVar('unicorn.foo.bar', event);
+    expect(value).toBe('baz');
+    expect(getDataElementValue).toHaveBeenCalledWith('unicorn.foo.bar', event);
   });
 
   // Accessing nested properties of a data element using dot-notation is unsupported because users
@@ -50,7 +53,8 @@ describe('function returned by createGetVar', function() {
     };
     var getVar = createGetVar(customVars, getDataElementDefinition, getDataElementValue);
 
-    expect(getVar('unicorn.foo.bar')).not.toBe('baz');
+    var value = getVar('unicorn.foo.bar');
+    expect(value).not.toBe('baz');
   });
 
   it('returns nested property on element using "this." prefix', function() {

--- a/src/createGetDataElementValue.js
+++ b/src/createGetDataElementValue.js
@@ -29,7 +29,7 @@ module.exports = function(
   replaceTokens,
   undefinedVarsReturnEmpty
 ) {
-  return function(name) {
+  return function(name, syntheticEvent) {
     var dataDef = getDataElementDefinition(name);
 
     if (!dataDef) {
@@ -54,7 +54,7 @@ module.exports = function(
     var value;
 
     try {
-      value = moduleExports(replaceTokens(dataDef.settings));
+      value = moduleExports(replaceTokens(dataDef.settings, syntheticEvent), syntheticEvent);
     } catch (e) {
       logger.error(getErrorMessage(dataDef, name, e.message, e.stack));
       return;

--- a/src/createGetVar.js
+++ b/src/createGetVar.js
@@ -75,7 +75,7 @@ module.exports = function(customVars, getDataElementDefinition, getDataElementVa
     if (getDataElementDefinition(variable)) {
       // Accessing nested properties of a data element using dot-notation is unsupported because
       // users can currently create data elements with periods in the name.
-      value = getDataElementValue(variable);
+      value = getDataElementValue(variable, syntheticEvent);
     } else {
       var propChain = variable.split('.');
       var variableHostName = propChain.shift();


### PR DESCRIPTION
When a data element is being retrieved from a condition or action of a rule, we should provide the rule's event object to the data element's library module. This will allow the data element to provide a value derived from the event. This can be useful when the event contains a snapshot of a user's data layer at the time the event occurred. It could also be useful if we ever want to provide rule-scoped data element types like Click Element ID.

This was requested by Stewart Schilling (Search Discovery) and corroborated by Lukas Cech.