### PR TITLE
Allow getExtensionSettings to accept event as parameter

### DIFF
--- a/src/createGetExtensionSettings.js
+++ b/src/createGetExtensionSettings.js
@@ -18,7 +18,7 @@
  * @returns {Function}
  */
 module.exports = function (replaceTokens, settings) {
-  return function () {
-    return settings ? replaceTokens(settings) : {};
+  return function (syntheticEvent) {
+    return settings ? replaceTokens(settings, syntheticEvent) : {};
   };
 };


### PR DESCRIPTION
## Description

The function turbine.getExtensionSettings() can potentially be called from inside any condition/action exposed from an extension. Hence, the extension configuration should also _be able_ to use the rule's synthetic event using %event%

## Related Issue

https://github.com/adobe/reactor-turbine/issues/157

## Motivation and Context

Passing the rule's synthetic event as parameter to turbine.getExtensionSettings() function call must be possible as this function internally calls replaceTokens() which replaces tokens with actual values. If in the extension configuration the user has used %event% as token, the turbine.getExtensionSettings() call from inside the action's/condition's module should be able to pass the event parameter it possess, so that the tokens are replaced with actual values coming from the event.

## How Has This Been Tested?

Not tested

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
