### PR TITLE
Add support for ES6 modules transpilled with Babel.

### DIFF
--- a/src/__tests__/createExecuteDelegateModule.test.js
+++ b/src/__tests__/createExecuteDelegateModule.test.js
@@ -54,6 +54,61 @@ describe('createExecuteDelegateModule returns a function that when called', func
     expect(moduleExportsSpy).toHaveBeenCalledWith(undefined, 'a', 'b');
   });
 
+  it('handles ES6 modules transpiled with Babel (with __esModule flag)', function () {
+    var moduleExportsSpy = jasmine
+      .createSpy('moduleExports')
+      .and.returnValue('module result');
+    var babelTranspiledModule = {
+      __esModule: true,
+      default: moduleExportsSpy
+    };
+    var getModuleExportsSpy = jasmine
+      .createSpy('getModuleExports')
+      .and.returnValue(babelTranspiledModule);
+
+    var moduleProvider = {
+      getModuleExports: getModuleExportsSpy,
+      getModuleDefinition: jasmine.createSpy().and.returnValue({})
+    };
+    var replaceTokens = emptyFn;
+    var settingsFileTransformer = emptyFn;
+
+    expect(
+      createExecuteDelegateModule(
+        moduleProvider,
+        replaceTokens,
+        settingsFileTransformer
+      )(moduleDescriptor, event, moduleCallParameters)
+    ).toBe('module result');
+    expect(getModuleExportsSpy).toHaveBeenCalledWith('path');
+    expect(moduleExportsSpy).toHaveBeenCalledWith(undefined, 'a', 'b');
+  });
+
+  it('throws an error if ES6 module default export is not a function', function () {
+    var babelTranspiledModule = {
+      __esModule: true,
+      default: 'not a function'
+    };
+    var getModuleExportsSpy = jasmine
+      .createSpy('getModuleExports')
+      .and.returnValue(babelTranspiledModule);
+
+    var moduleProvider = {
+      getModuleExports: getModuleExportsSpy,
+      getModuleDefinition: jasmine.createSpy().and.returnValue({})
+    };
+    var replaceTokens = emptyFn;
+    var settingsFileTransformer = emptyFn;
+
+    expect(function () {
+      createExecuteDelegateModule(
+        moduleProvider,
+        replaceTokens,
+        settingsFileTransformer
+      )(moduleDescriptor, event, moduleCallParameters);
+    }).toThrow(new Error('Module did not export a function.'));
+  });
+
   it(
     'calls the module export function with an empty array when ' +
       ' module call parameters are not provided',

--- a/src/createExecuteDelegateModule.js
+++ b/src/createExecuteDelegateModule.js
@@ -23,6 +23,10 @@ module.exports = function (
       moduleDescriptor.modulePath
     );
 
+    moduleExports = moduleExports.__esModule
+      ? moduleExports.default
+      : moduleExports;
+
     if (typeof moduleExports !== 'function') {
       throw new Error(MODULE_NOT_FUNCTION_ERROR);
     }


### PR DESCRIPTION
## Description

This is the second attempt for making Tags support ES6 library modules that are transpiled with Babel.

In the [first try](https://github.com/adobe/reactor-turbine/commit/7b2e67eb3ecc06f889a94c06af0c442bbbf903ae), I was changing how the internal Tags require was working. By doing that, I broke the DemandBase extension that was expecting require to return an object having the default property.

This time, I just change how Tags is executing a module. If module.exports is a method, it will get executed. If it is an object that has a default key with a function as value, it will execute that.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Right now the Web SDK extension cannot be fully ES6 compatible because the library modules are still common js. Because of that we cannot add `type: 'module'` inside package.json, which also forces us to have files with various extensions: .js, .cjs, .mjs.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested it against modules compiled with Babel in this PR: https://github.com/adobe/reactor-extension-alloy/pull/466

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
