### PR TITLE
POC (do not merge): opt-in deferred data-element evaluation for #125

### DIFF
--- a/POC-issue-125.md
+++ b/POC-issue-125.md
@@ -1,0 +1,61 @@
+# POC: deferred data-element evaluation (issue #125)
+
+**Status: proof-of-concept for discussion — NOT a merge-ready fix.**
+
+## The problem (from #125)
+
+Turbine resolves `%data element%` tokens **eagerly**, at the moment a delegate
+module runs (`createExecuteDelegateModule.js` → `replaceTokens(moduleSettings)`,
+and `createGetExtensionSettings.js` → `replaceTokens(settings)`). When a *dynamic*
+data element (e.g. Core > Random Number) is used in an **extension/component
+configuration**, its value is frozen to whatever it was when that configuration
+module first ran — not when the action (e.g. an Analytics beacon) actually fires.
+The Launch author expects the value to be evaluated at fire-time.
+
+## What this POC changes
+
+A single, self-contained change in `src/createReplaceTokens.js`: a token may opt
+**out** of eager evaluation by prefixing its name with `~`.
+
+| Input token   | Behavior                                                        |
+| ------------- | -------------------------------------------------------------- |
+| `%foo%`       | unchanged — resolved eagerly, exactly as today                 |
+| `%~foo%`      | emitted as the still-unresolved token `%foo%` (one `~` stripped) |
+
+The delegate module then receives the literal `%foo%` in its settings and can
+resolve it *itself*, at the real action-time, via `turbine.replaceTokens(...)`.
+Calling `replaceTokens` again on the emitted `%foo%` resolves it normally, so
+"defer once, resolve later" composes cleanly (verified by the added unit tests).
+
+Verified locally against the real module:
+
+```
+PASS | eager single token          | %foo%              -> value-of-foo
+PASS | eager inline                 | a %foo% b          -> a value-of-foo b
+PASS | deferred single -> unresolved| %~foo%             -> %foo%
+PASS | deferred inline mixed        | %~foo% and %bar%   -> %foo% and value-of-bar
+PASS | pass1 defers                 | %~random number%   -> %random number%
+PASS | pass2 resolves               | %random number%    -> value-of-random number
+```
+
+## Why this is a POC and not the whole fix
+
+The #125 discussion asks for a **component-level "Evaluate data element at
+runtime" setting**. That is a platform feature that turbine alone cannot deliver:
+
+1. **No component-level settings exist for extensions** — the flag has to be
+   modeled and stored somewhere the extension SDK and Launch UI can expose it.
+2. **Extensions must cooperate** — each extension has to actually call
+   `turbine.replaceTokens` at action-time on the fields it wants to defer. This
+   POC only provides the turbine-side capability; it does not make any extension
+   use it.
+3. **Token-syntax choice is provisional** — `~` is convenient for a POC but the
+   escape/marker (and its interaction with data-element names that could
+   legitimately start with `~`) needs a design decision by the maintainers.
+4. **Docs / backward-compat** — the "single token returns raw value" contract and
+   the developer docs on token replacement would need updating.
+
+In other words: this demonstrates a *mechanism* the feature could build on, and
+gives the maintainers something concrete to react to — it is not a drive-by
+implementation of the feature. It intentionally has **not** been opened as a PR
+against `adobe/reactor-turbine`.

--- a/src/__tests__/createReplaceTokens.test.js
+++ b/src/__tests__/createReplaceTokens.test.js
@@ -140,6 +140,43 @@ describe('function returned by replaceTokens', function () {
     }
   );
 
+  // POC for adobe/reactor-turbine#125: deferred (lazy) token evaluation.
+  it('leaves a deferred token (%~foo%) unresolved so it can be evaluated later', function () {
+    getVar = function () {
+      return 'shouldNotBeUsed';
+    };
+    var replaceTokens = createReplaceTokens(
+      isVar,
+      getVar,
+      undefinedVarsReturnEmpty
+    );
+
+    // A single deferred token is emitted as the plain, still-unresolved token.
+    expect(replaceTokens('%~foo%')).toBe('%foo%');
+
+    // Inline: the deferred token is emitted unresolved while a normal token in
+    // the same string is still replaced.
+    expect(replaceTokens('%~foo% and %bar%')).toBe('%foo% and shouldNotBeUsed');
+  });
+
+  it('resolves a previously deferred token on a subsequent pass', function () {
+    getVar = function (variableName) {
+      return 'value-of-' + variableName;
+    };
+    var replaceTokens = createReplaceTokens(
+      isVar,
+      getVar,
+      undefinedVarsReturnEmpty
+    );
+
+    // First pass (e.g. at module-run time) defers evaluation...
+    var deferred = replaceTokens('%~random number%');
+    expect(deferred).toBe('%random number%');
+
+    // ...and a later pass (e.g. when the action actually fires) resolves it.
+    expect(replaceTokens(deferred)).toBe('value-of-random number');
+  });
+
   it('returns the argument unmodified if it is an unsupported type', function () {
     var replaceTokens = createReplaceTokens(
       isVar,

--- a/src/createReplaceTokens.js
+++ b/src/createReplaceTokens.js
@@ -53,15 +53,39 @@ function injectCreateReplaceTokens({ logger }) {
      * @param event {Object} The event object to use for tokens in the form of %target.property%.
      * @returns {*}
      */
+    // POC for adobe/reactor-turbine#125.
+    // A token may opt out of eager (module-run-time) evaluation by prefixing its
+    // name with "~", e.g. "%~myDataElement%". Turbine strips one "~" and leaves
+    // the remaining "%myDataElement%" token in place, unresolved, so the delegate
+    // module can resolve it itself at the exact moment its action runs (via
+    // turbine.replaceTokens). This addresses the case where a dynamic data
+    // element used in extension/component configuration was frozen to the value
+    // it had when that module was first executed instead of when the beacon
+    // actually fires.
+    var DEFERRED_TOKEN_PREFIX = '~';
+
+    var isDeferredToken = function (variableName) {
+      return variableName.charAt(0) === DEFERRED_TOKEN_PREFIX;
+    };
+
+    // Strip one level of "~" so the emitted token can be resolved on a later pass.
+    var deferToken = function (variableName) {
+      return '%' + variableName.slice(1) + '%';
+    };
+
     replaceTokensInString = function (str, syntheticEvent) {
       // Is the string a single data element token and nothing else?
       var result = /^%([^%]+)%$/.exec(str);
 
       if (result) {
-        return getVarValue(str, result[1], syntheticEvent);
+        return isDeferredToken(result[1])
+          ? deferToken(result[1])
+          : getVarValue(str, result[1], syntheticEvent);
       } else {
         return str.replace(/%(.+?)%/g, function (token, variableName) {
-          return getVarValue(token, variableName, syntheticEvent);
+          return isDeferredToken(variableName)
+            ? deferToken(variableName)
+            : getVarValue(token, variableName, syntheticEvent);
         });
       }
     };


### PR DESCRIPTION
> **Draft / proof-of-concept for discussion — not intended to be merged as-is.**

Follow-up to my comment on #125 (https://github.com/adobe/reactor-turbine/issues/125#issuecomment-5028369701). This makes that proposal concrete so it's easy to look at and react to.

## Problem (#125)

Turbine resolves `%data element%` tokens **eagerly**, when a delegate module runs (`createExecuteDelegateModule.js` → `replaceTokens(moduleSettings)`; also `createGetExtensionSettings.js`). A *dynamic* data element used in extension/component configuration is therefore frozen to the value it had when that module first ran — not when the action (e.g. an Analytics beacon) actually fires.

## Change

A token can opt out of eager evaluation by prefixing its name with `~`:

| Token | Behavior |
| --- | --- |
| `%foo%` | unchanged — resolved eagerly, exactly as today |
| `%~foo%` | emitted as the still-unresolved `%foo%` (one `~` stripped) |

The delegate module receives the literal `%foo%` and resolves it itself, at action-time, via `turbine.replaceTokens(...)`. Because a second pass over `%foo%` resolves normally, "defer once, resolve later" composes cleanly. Adds unit tests in `createReplaceTokens.test.js` and a `POC-issue-125.md` write-up.

Verified locally against the real module:

```
eager single / inline ........ unchanged
%~foo% ....................... %foo%                    (deferred, unresolved)
%~foo% and %bar% ............. %foo% and <resolved bar>
%~random number% -> %random number% -> <fresh value>   (two-pass)
```

## Why this is a draft, not a finished feature

- The `~` marker is provisional. #125 really asks for a component-level "evaluate at runtime" setting, which extensions don't currently have — the escape syntax (and data-element names that legitimately start with `~`) needs a design decision.
- Extensions must actually call `turbine.replaceTokens` at action-time on the fields they want to defer; turbine can't do that on their behalf.
- The "single token returns the raw (non-string) value" contract and the token-replacement docs would need updating.

Opening as a draft purely so the mechanism is concrete for the #125 discussion — happy to change the approach, swap the marker, or close it if you'd rather keep the design in the issue. Direction is your call.