### PR TITLE
Assert all logged arguments in logger unit test

### DIFF
--- a/src/__tests__/logger.test.js
+++ b/src/__tests__/logger.test.js
@@ -52,7 +52,7 @@ describe('logger', function () {
         var arg2 = {};
         logger[loggerMethodName](arg1, arg2);
         expect(calls.count()).toBe(1);
-        expect(calls.argsFor(0)[0]).toBe(launchPrefix, arg1, arg2);
+        expect(calls.argsFor(0)).toEqual([launchPrefix, arg1, arg2]);
       }
     );
 


### PR DESCRIPTION
## Description

In `src/__tests__/logger.test.js`, the "logs args when output is enabled" spec reads:

```js
expect(calls.argsFor(0)[0]).toBe(launchPrefix, arg1, arg2);
```

Jasmine's `toBe()` accepts a single expected value, so `arg1` and `arg2` are silently ignored — the spec only ever verified the launch prefix and never checked that the logged arguments are actually forwarded to the console method. If `process()` in `src/logger.js` dropped or reordered the caller's arguments, this spec would still pass.

This change compares the full arguments array instead:

```js
expect(calls.argsFor(0)).toEqual([launchPrefix, arg1, arg2]);
```

which matches what the "creates a prefixed logger" spec in the same file already verifies via `toHaveBeenCalledWith(launchPrefix, bracketId, arg1, arg2)`.

## Testing

- `karma start karma.unit.conf.js --browsers=ChromeHeadless --no-coverage --single-run` — 374/374 pass before and after (the logger does forward the args correctly; the assertion was just too weak to prove it)
- `eslint src/__tests__/logger.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)